### PR TITLE
[FIX] Add method 'add_module_dependencies' on openupgrade_loading.py

### DIFF
--- a/openerp/modules/loading.py
+++ b/openerp/modules/loading.py
@@ -54,6 +54,7 @@ import openerp.release as release
 import openerp.tools as tools
 import openerp.tools.osutil as osutil
 
+from openerp.openupgrade import openupgrade_loading
 from openerp.tools.safe_eval import safe_eval as eval
 from openerp.tools.translate import _
 from openerp.modules.module import \
@@ -411,7 +412,7 @@ def load_marked_modules(cr, graph, states, force, progressdict, report, loaded_m
     while True:
         cr.execute("SELECT name from ir_module_module WHERE state IN %s" ,(tuple(states),))
         module_list = [name for (name,) in cr.fetchall() if name not in graph]
-        module_list = openupgrade.add_module_dependencies(cr, module_list)
+        module_list = openupgrade_loading.add_module_dependencies(cr, module_list)
         graph.add_modules(cr, module_list, force)
         _logger.debug('Updating graph with %d more modules', len(module_list))
         loaded, processed = load_module_graph(cr, graph, progressdict, report=report, skip_modules=loaded_modules, registry=registry)

--- a/openerp/openupgrade/openupgrade_loading.py
+++ b/openerp/openupgrade/openupgrade_loading.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2011-2012 Therp BV (<http://therp.nl>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import logging
+
+# A collection of functions used in
+# openerp/modules/loading.py
+
+logger = logging.getLogger('OpenUpgrade')
+
+
+def add_module_dependencies(cr, module_list):
+    """
+    Select (new) dependencies from the modules in the list
+    so that we can inject them into the graph at upgrade
+    time. Used in the modified OpenUpgrade Server,
+    not to be used in migration scripts
+    """
+    dependencies = module_list
+    while dependencies:
+        cr.execute("""
+            SELECT DISTINCT dep.name
+            FROM
+                ir_module_module,
+                ir_module_module_dependency dep
+            WHERE
+                module_id = ir_module_module.id
+                AND ir_module_module.name in %s
+                AND dep.name not in %s
+            """, (tuple(dependencies), tuple(module_list),))
+        dependencies = [x[0] for x in cr.fetchall()]
+        module_list += dependencies
+    return module_list


### PR DESCRIPTION
To finish correctly the migration.
